### PR TITLE
feat: add discover rooms

### DIFF
--- a/lib/config/routes.dart
+++ b/lib/config/routes.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:fluffychat/pages/chat_list/rooms_list/discover_rooms_view.dart';
 import 'package:fluffychat/pages/login/auto_login.dart';
 import 'package:flutter/material.dart';
 
@@ -153,6 +154,14 @@ abstract class AppRoutes {
                   ),
           ),
           routes: [
+            GoRoute(
+                  path: 'discover',
+                  pageBuilder: (context, state) => defaultPageBuilder(
+                    context,
+                    state,
+                    const DiscoverRoomsView(),
+                  ),
+                ),
             GoRoute(
               path: 'archive',
               pageBuilder: (context, state) => defaultPageBuilder(

--- a/lib/config/themes.dart
+++ b/lib/config/themes.dart
@@ -268,10 +268,10 @@ extension BubbleColorTheme on ThemeData {
 }
 
 extension ColorId on ColorScheme {
-  // logos 
+  // logos
   String get logoHorizontalSemFundo => 'assets/logo_horizontal_semfundo.png';
   String get logoSingleSemFundo => 'assets/logo_single_semfundo.png';
-  
+
   // geral
   Color get normalSnackBarTextColor => tertiary;
   Color get oopsMessageTextColor => onSecondaryContainer;
@@ -295,27 +295,27 @@ extension ColorId on ColorScheme {
 
   // menu login
   Icon get menuIconStore => Icon(
-                Icons.shopping_cart,
-                color: loginMenuIconColor,
-                size: 20,
-              ); 
+        Icons.shopping_cart,
+        color: loginMenuIconColor,
+        size: 20,
+      );
 
   Icon get menuIconCourse => Icon(
-                Icons.book,
-                color: loginMenuIconColor,
-                size: 20,
-              );
-  
+        Icons.book,
+        color: loginMenuIconColor,
+        size: 20,
+      );
+
   Icon get menuIconPodcast => Icon(
-                Icons.mic,
-                color: loginMenuIconColor,
-                size: 20,
-              );
+        Icons.mic,
+        color: loginMenuIconColor,
+        size: 20,
+      );
 
   Icon get menuIconInfo => Icon(
-                    Icons.info_outlined,
-                    color: loginMenuIconColor,
-                  );
+        Icons.info_outlined,
+        color: loginMenuIconColor,
+      );
 
   Color get loginMenuIconColor => primary;
   Color get loginMenuTextColor => onSurface;
@@ -329,6 +329,12 @@ extension ColorId on ColorScheme {
   Color get scaffoldBorderColor => primary;
 
   // chatlist
+  // discover
+  Color get chatlistDiscoverTextColor => tertiary;
+  Color get chatlistDiscoverTileGroupNameTextColor => primary;
+  Color get chatlistDiscoverTileDescriptionTextColor => tertiary;
+  Color get chatlistDiscoverButtonTextColor => tertiary;
+  Color get chatlistDiscoverButtonColor => primary;
   // view
   Color get chatListBackground => surface;
 
@@ -345,42 +351,42 @@ extension ColorId on ColorScheme {
   Color get circularProgressIndicatorColor => primary;
 
   // client chooser button
-   Icon get iconEdit => Icon(
-                Icons.edit_outlined,
-                color: clientChooserButtonIconColor,
-                size: 22,
-              );
+  Icon get iconEdit => Icon(
+        Icons.edit_outlined,
+        color: clientChooserButtonIconColor,
+        size: 22,
+      );
 
   Icon get iconHome => Icon(
-                Icons.home,
-                color: clientChooserButtonIconColor,
-                size: 22,
-              );
-  
+        Icons.home,
+        color: clientChooserButtonIconColor,
+        size: 22,
+      );
+
   Icon get iconCourse => Icon(
-                Icons.book,
-                color: clientChooserButtonIconColor,
-                size: 22,
-              );
+        Icons.book,
+        color: clientChooserButtonIconColor,
+        size: 22,
+      );
 
   Icon get iconSetting => Icon(
-                Icons.settings,
-                color: clientChooserButtonIconColor,
-                size: 22,
-              );
+        Icons.settings,
+        color: clientChooserButtonIconColor,
+        size: 22,
+      );
 
   Icon get iconInfo => Icon(
-                Icons.info_outlined,
-                color: clientChooserButtonIconColor,
-                size: 22,
-              );
+        Icons.info_outlined,
+        color: clientChooserButtonIconColor,
+        size: 22,
+      );
 
   Icon get iconShare => Icon(
-                Icons.adaptive.share_outlined,
-                color: clientChooserShareIconColor,
-                size: 22,
-              );
-  
+        Icons.adaptive.share_outlined,
+        color: clientChooserShareIconColor,
+        size: 22,
+      );
+
   Color get clientChooserButtonIconColor => tertiary;
   Color get clientChooserButtonTextColor => tertiary;
   Color get clientChooserShareIconColor => primary;
@@ -413,40 +419,40 @@ extension ColorId on ColorScheme {
 
   // navirail
   Icon get navirailIconHomeUnselected => Icon(
-                                Icons.home,
-                                color: unselectediconColor,
-                                size: 40,
-                              );
+        Icons.home,
+        color: unselectediconColor,
+        size: 40,
+      );
 
   Icon get navirailIconChatUnselected => Icon(
-                                Icons.chat_bubble_outline,
-                                color: unselectediconColor,
-                                size: 40,
-                              );
+        Icons.chat_bubble_outline,
+        color: unselectediconColor,
+        size: 40,
+      );
 
   Icon get navirailIconChatSelected => Icon(
-                                Icons.chat_bubble_outline,
-                                color: selectediconColor,
-                                size: 40,
-                              );
+        Icons.chat_bubble_outline,
+        color: selectediconColor,
+        size: 40,
+      );
 
   Icon get navirailIconCourseUnselected => Icon(
-                                Icons.book,
-                                color: unselectediconColor,
-                                size: 40,
-                              );
+        Icons.book,
+        color: unselectediconColor,
+        size: 40,
+      );
 
   Icon get navirailIconSettingUnselected => Icon(
-                          Icons.settings,
-                          color: unselectediconColor,
-                          size: 40,
-                        );
+        Icons.settings,
+        color: unselectediconColor,
+        size: 40,
+      );
 
   Icon get navirailIconSettingSelected => Icon(
-                          Icons.settings,
-                          color: selectediconColor,
-                          size: 40,
-                        );
+        Icons.settings,
+        color: selectediconColor,
+        size: 40,
+      );
 
   Color get selectedContainerColor => primary;
   Color get selectediconColor => primary;

--- a/lib/pages/chat_list/chat_list_view.dart
+++ b/lib/pages/chat_list/chat_list_view.dart
@@ -1,9 +1,12 @@
+import 'package:fluffychat/pages/chat_list/rooms_list/discover_rooms_view.dart';
+import 'package:fluffychat/widgets/matrix.dart';
 import 'package:flutter/material.dart';
 
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/pages/chat_list/chat_list.dart';
 import 'package:fluffychat/widgets/navigation_rail.dart';
+import 'package:go_router/go_router.dart';
 import 'chat_list_body.dart';
 import 'package:fluffychat/widgets/streaming/audio_player_streaming.dart';
 
@@ -49,56 +52,94 @@ class ChatListView extends StatelessWidget {
               excludeFromSemantics: true,
               behavior: HitTestBehavior.translucent,
               child: Scaffold(
-                body: Stack(
-                  children: [
-                    ChatListViewBody(controller),
-                    Positioned(
-                      bottom: 0,
-                      left: 0,
-                      right: 0,
-                      child: Center(
-                        child: ConstrainedBox(
-                          constraints: const BoxConstraints(maxWidth: 500),
-                          child: Container(
-                            width: double.infinity,
-                            decoration: BoxDecoration(
-                              color: theme.colorScheme.chatListBackground,
-                            ),
-                            padding: const EdgeInsets.only(
-                              left: 20,
-                              right: 20,
-                              bottom: 16,
-                              top: 20,
-                            ),
-                            child: const AudioPlayerStreaming(),
+                  body: Stack(
+                children: [
+                  ChatListViewBody(controller),
+
+                  // 🎵 Player (fica embaixo)
+                  Positioned(
+                    bottom: 0,
+                    left: 0,
+                    right: 0,
+                    child: Center(
+                      child: ConstrainedBox(
+                        constraints: const BoxConstraints(maxWidth: 500),
+                        child: Container(
+                          width: double.infinity,
+                          decoration: BoxDecoration(
+                            color: theme.colorScheme.chatListBackground,
                           ),
+                          padding: const EdgeInsets.only(
+                            left: 20,
+                            right: 20,
+                            bottom: 16,
+                            top: 20,
+                          ),
+                          child: const AudioPlayerStreaming(),
                         ),
                       ),
                     ),
-                  ],
-                ),
-                // floatingActionButton: !controller.isSearchMode &&
-                //         controller.activeSpaceId == null
-                //     ? FloatingActionButton.extended(
-                //         backgroundColor: Theme.of(context).colorScheme.primary,
-                //         foregroundColor: Colors.white,
-                //         elevation: 0,
-                //         onPressed: () => context.go('/rooms/newprivatechat'),
-                //         icon: Icon(
-                //           Icons.add_outlined,
-                //           color: Theme.of(context).colorScheme.onPrimary,
-                //         ),
-                //         label: Text(
-                //           L10n.of(context).chat,
-                //           overflow: TextOverflow.fade,
-                //           style: TextStyle(
-                //             color: Theme.of(context).colorScheme.onPrimary,
-                //             fontSize: 15,
-                //           ),
-                //         ),
-                //       )
-                //     : const SizedBox.shrink(),
-              ),
+                  ),
+
+                  // 🔒 BOTÃO — SEMPRE POR ÚLTIMO
+                  Positioned(
+                    bottom: 220,
+                    right: 12,
+                    child: SafeArea(
+                      top: false,
+                      child: ElevatedButton.icon(
+                        style: ElevatedButton.styleFrom(
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          backgroundColor:
+                              theme.colorScheme.chatlistDiscoverButtonColor,
+                          foregroundColor:
+                              theme.colorScheme.chatlistDiscoverButtonTextColor,
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 16, vertical: 10),
+                          minimumSize: const Size(130, 25),
+                        ),
+                        icon: Icon(Icons.explore,
+                            color: theme
+                                .colorScheme.chatlistDiscoverButtonTextColor),
+                        label: Text(
+                          'Descobrir Grupos',
+                          style: TextStyle(
+                              color: theme
+                                  .colorScheme.chatlistDiscoverButtonTextColor),
+                        ),
+                        onPressed: () {
+                          context.go('/rooms/discover');
+                        },
+                      ),
+                    ),
+                  ),
+                ],
+              )
+
+                  // floatingActionButton: !controller.isSearchMode &&
+                  //         controller.activeSpaceId == null
+                  //     ? FloatingActionButton.extended(
+                  //         backgroundColor: Theme.of(context).colorScheme.primary,
+                  //         foregroundColor: Colors.white,
+                  //         elevation: 0,
+                  //         onPressed: () => context.go('/rooms/newprivatechat'),
+                  //         icon: Icon(
+                  //           Icons.add_outlined,
+                  //           color: Theme.of(context).colorScheme.onPrimary,
+                  //         ),
+                  //         label: Text(
+                  //           L10n.of(context).chat,
+                  //           overflow: TextOverflow.fade,
+                  //           style: TextStyle(
+                  //             color: Theme.of(context).colorScheme.onPrimary,
+                  //             fontSize: 15,
+                  //           ),
+                  //         ),
+                  //       )
+                  //     : const SizedBox.shrink(),
+                  ),
             ),
           ),
         ],

--- a/lib/pages/chat_list/chat_list_view.dart
+++ b/lib/pages/chat_list/chat_list_view.dart
@@ -55,8 +55,6 @@ class ChatListView extends StatelessWidget {
                   body: Stack(
                 children: [
                   ChatListViewBody(controller),
-
-                  // 🎵 Player (fica embaixo)
                   Positioned(
                     bottom: 0,
                     left: 0,
@@ -80,8 +78,6 @@ class ChatListView extends StatelessWidget {
                       ),
                     ),
                   ),
-
-                  // 🔒 BOTÃO — SEMPRE POR ÚLTIMO
                   Positioned(
                     bottom: 220,
                     right: 12,

--- a/lib/pages/chat_list/rooms_list/discover_rooms_view.dart
+++ b/lib/pages/chat_list/rooms_list/discover_rooms_view.dart
@@ -28,15 +28,15 @@ class DiscoverRoom {
       roomId: json['room_id'],
       accessType:
           json['type'] == 'paid' ? RoomAccessType.paid : RoomAccessType.free,
-      memberCount: json['member_count'],
+      memberCount: json['member_count'] ?? 0,
       price: json['price'] ?? 0,
     );
   }
-}
+} 
 
 Future<List<DiscoverRoom>> fetchDiscoverRooms(Client client) async {
   final uri = Uri.parse(
-    '${client.homeserver}/_matrix/discover/rooms',
+    '${client.homeserver}/_matrix/admin/rooms',
   );
 
   final response = await http.get(
@@ -231,9 +231,10 @@ class _DiscoverRoomsViewState extends State<DiscoverRoomsView> {
                           if (!approved) return;
                         }
 
-                        final community = room.accessType == RoomAccessType.paid
-                            ? 'vip'
-                            : 'free';
+                        final community =
+                            room.accessType == RoomAccessType.paid
+                                ? 'vip'
+                                : 'free';
 
                         await inviteToCommunity(
                           client: client,

--- a/lib/pages/chat_list/rooms_list/discover_rooms_view.dart
+++ b/lib/pages/chat_list/rooms_list/discover_rooms_view.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'package:go_router/go_router.dart';
 import 'package:http/http.dart' as http;
 import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/widgets/matrix.dart';
@@ -8,36 +9,41 @@ import 'package:matrix/matrix.dart';
 enum RoomAccessType { free, paid }
 
 class DiscoverRoom {
-  final String name;
   final String roomId;
+  final String name;
+  final String keyword;
   final RoomAccessType accessType;
-  final int memberCount;
   final int price;
+  final int memberCount;
 
   DiscoverRoom({
-    required this.name,
     required this.roomId,
+    required this.name,
+    required this.keyword,
     required this.accessType,
-    required this.memberCount,
     required this.price,
+    required this.memberCount,
   });
 
   factory DiscoverRoom.fromJson(Map<String, dynamic> json) {
     return DiscoverRoom(
-      name: json['name'],
       roomId: json['room_id'],
+      name: json['name'] ?? 'Sem nome',
+      keyword: json['keyword'],
       accessType:
-          json['type'] == 'paid' ? RoomAccessType.paid : RoomAccessType.free,
-      memberCount: json['member_count'] ?? 0,
+          json['access_type'] == 'paid'
+              ? RoomAccessType.paid
+              : RoomAccessType.free,
       price: json['price'] ?? 0,
+      memberCount: json['member_count'] ?? 0,
     );
   }
 } 
 
+
 Future<List<DiscoverRoom>> fetchDiscoverRooms(Client client) async {
-  final uri = Uri.parse(
-    '${client.homeserver}/_matrix/admin/rooms',
-  );
+  final uri =
+      Uri.parse('${client.homeserver}/_synapse/room_service/discover');
 
   final response = await http.get(
     uri,
@@ -51,31 +57,27 @@ Future<List<DiscoverRoom>> fetchDiscoverRooms(Client client) async {
   debugPrint('DISCOVER BODY: ${response.body}');
 
   if (response.statusCode != 200) {
-    throw Exception(
-      'HTTP ${response.statusCode}: ${response.body}',
-    );
+    throw Exception('HTTP ${response.statusCode}: ${response.body}');
   }
 
   final decoded = jsonDecode(utf8.decode(response.bodyBytes));
 
-  if (decoded is! List) {
-    throw Exception('Invalid response format');
-  }
+  final List roomsJson = decoded['rooms'];
 
-  return decoded
-      .map<DiscoverRoom>(
-        (e) => DiscoverRoom.fromJson(e),
-      )
+  return roomsJson
+      .map<DiscoverRoom>((e) => DiscoverRoom.fromJson(e))
       .toList();
 }
 
-Future<void> inviteToCommunity({
+
+
+Future<void> inviteToRoom({
   required Client client,
-  required String community,
+  required String keyword,
+  required String userId,
 }) async {
-  final uri = Uri.parse(
-    '${client.homeserver}/_matrix/invite',
-  );
+  final uri =
+      Uri.parse('${client.homeserver}/_synapse/room_service/invite');
 
   final response = await http.post(
     uri,
@@ -84,7 +86,8 @@ Future<void> inviteToCommunity({
       'Content-Type': 'application/json',
     },
     body: jsonEncode({
-      'community': community,
+      'keyword': keyword,
+      'user_id': userId,
     }),
   );
 
@@ -93,10 +96,10 @@ Future<void> inviteToCommunity({
 
   if (response.statusCode != 200) {
     throw Exception(
-      'Invite failed: ${response.statusCode} ${response.body}',
-    );
+        'Invite failed: ${response.statusCode} ${response.body}');
   }
 }
+
 
 class DiscoverRoomsView extends StatefulWidget {
   const DiscoverRoomsView({super.key});
@@ -106,153 +109,188 @@ class DiscoverRoomsView extends StatefulWidget {
 }
 
 class _DiscoverRoomsViewState extends State<DiscoverRoomsView> {
-  late Future<List<DiscoverRoom>> future = Future.value([]);
+  late Future<List<DiscoverRoom>> future;
+
 
   @override
   void initState() {
     super.initState();
-
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      final client = Matrix.of(context).client;
-      setState(() {
-        future = fetchDiscoverRooms(client);
-      });
-    });
+    final client = Matrix.of(context).client;
+    future = fetchDiscoverRooms(client);
   }
 
-  @override
-  Widget build(BuildContext context) {
-    final client = Matrix.of(context).client;
-    final theme = Theme.of(context);
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(
-          'Descobrir Grupos',
-          style: TextStyle(
-            color: theme.colorScheme.chatlistDiscoverTextColor,
-          ),
+  static const double _bottomButtonHeight = 72;
+@override
+Widget build(BuildContext context) {
+  final client = Matrix.of(context).client;
+  final theme = Theme.of(context);
+  final userId = client.userID.toString();
+
+
+  return Scaffold(
+    appBar: AppBar(
+      title: Text(
+        'Descobrir Grupos',
+        style: TextStyle(
+          color: theme.colorScheme.chatlistDiscoverTextColor,
         ),
       ),
-      body: FutureBuilder<List<DiscoverRoom>>(
-        future: future,
-        builder: (context, snapshot) {
-          if (snapshot.connectionState == ConnectionState.waiting) {
-            return const Center(child: CircularProgressIndicator());
-          }
 
-          if (snapshot.hasError) {
-            return Center(
-              child: Text(
-                'Erro ao carregar grupos',
-                style: TextStyle(color: theme.colorScheme.error),
+    ),
+    bottomNavigationBar: SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            ElevatedButton.icon(
+              style: ElevatedButton.styleFrom(
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                backgroundColor: theme.colorScheme.chatlistDiscoverButtonColor,
+                foregroundColor:
+                    theme.colorScheme.chatlistDiscoverButtonTextColor,
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 12,
+                ),
               ),
-            );
-          }
+              icon: const Icon(Icons.add),
+              label: const Text('Novo Grupo'),
+              onPressed: () {
+                context.go('/rooms/newgroup');
+              },
+            ),
+          ],
+        ),
+      ),
+    ),
+    body: FutureBuilder<List<DiscoverRoom>>(
+      future: future,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
 
-          final rooms = snapshot.data!;
+        if (snapshot.hasError) {
+          return Center(
+            child: Text(
+              'Erro ao carregar grupos',
+              style: TextStyle(color: theme.colorScheme.error),
+            ),
+          );
+        }
 
-          if (rooms.isEmpty) {
-            return const Center(child: Text('Nenhum grupo disponível'));
-          }
+        final rooms = snapshot.data!;
 
-          return ListView.builder(
-            itemCount: rooms.length,
-            itemBuilder: (context, index) {
-              final room = rooms[index];
+        if (rooms.isEmpty) {
+          return const Center(child: Text('Nenhum grupo disponível'));
+        }
 
-              return Padding(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                child: Material(
-                  borderRadius: BorderRadius.circular(14),
-                  color: theme.colorScheme.secondary.withValues(alpha: 0.4),
-                  child: ListTile(
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(14),
-                    ),
-                    title: Text(
-                      room.name,
-                      style: TextStyle(
-                        color: theme
-                            .colorScheme.chatlistDiscoverTileGroupNameTextColor,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                    subtitle: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          room.accessType == RoomAccessType.paid
-                              ? 'Premium • R\$ ${(room.price / 100).toStringAsFixed(2)}'
-                              : 'Entrada livre',
-                          style: TextStyle(
-                            fontSize: 12,
-                            color: theme.colorScheme
-                                .chatlistDiscoverTileDescriptionTextColor,
-                          ),
-                        ),
-                        const SizedBox(height: 4),
-                        Row(
-                          children: [
-                            Icon(
-                              Icons.person_outline,
-                              size: 16,
-                              color: theme.colorScheme
-                                  .chatlistDiscoverTileDescriptionTextColor,
-                            ),
-                            const SizedBox(width: 4),
-                            Text(
-                              '${room.memberCount} participantes',
-                              style: TextStyle(
-                                fontSize: 12,
-                                color: theme.colorScheme
-                                    .chatlistDiscoverTileDescriptionTextColor,
-                              ),
-                            ),
-                          ],
-                        ),
-                      ],
-                    ),
-                    trailing: ElevatedButton(
-                      child: Text(
-                        room.accessType == RoomAccessType.free
-                            ? 'Entrar'
-                            : 'Desbloquear',
-                        style: TextStyle(
-                          color:
-                              theme.colorScheme.chatlistDiscoverButtonTextColor,
-                        ),
-                      ),
-                      onPressed: () async {
-                        if (room.accessType == RoomAccessType.paid) {
-                          final approved =
-                              await _showFakePayment(context, room.price);
-                          if (!approved) return;
-                        }
+        return ListView.builder(
+          padding: const EdgeInsets.only(bottom: _bottomButtonHeight + 24),
+          itemCount: rooms.length,
+          itemBuilder: (context, index) {
+            final room = rooms[index];
 
-                        final community =
-                            room.accessType == RoomAccessType.paid
-                                ? 'vip'
-                                : 'free';
-
-                        await inviteToCommunity(
-                          client: client,
-                          community: community,
-                        );
-
-                        if (context.mounted) Navigator.pop(context);
-                      },
+            return Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: Material(
+                borderRadius: BorderRadius.circular(14),
+                color: theme.colorScheme.secondary.withValues(alpha: 0.4),
+                child: ListTile(
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(14),
+                  ),
+                  title: Text(
+                    room.name,
+                    style: TextStyle(
+                      color: theme.colorScheme.chatlistDiscoverTileGroupNameTextColor,
+                      fontWeight: FontWeight.bold,
                     ),
                   ),
+                  subtitle: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        room.accessType == RoomAccessType.paid
+                            ? 'Premium • R\$ ${(room.price / 100).toStringAsFixed(2)}'
+                            : 'Entrada livre',
+                        style: TextStyle(
+                          fontSize: 12,
+                          color: theme.colorScheme.chatlistDiscoverTileDescriptionTextColor,
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      Row(
+                        children: [
+                          Icon(
+                            Icons.person_outline,
+                            size: 16,
+                            color: theme.colorScheme.chatlistDiscoverTileDescriptionTextColor,
+                          ),
+                          const SizedBox(width: 4),
+                          Text(
+                            '${room.memberCount} participantes',
+                            style: TextStyle(
+                              fontSize: 12,
+                              color: theme.colorScheme.chatlistDiscoverTileDescriptionTextColor,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                  trailing: ElevatedButton(
+                    child: Text(
+                      room.accessType == RoomAccessType.free
+                          ? 'Entrar'
+                          : 'Desbloquear',
+                      style: TextStyle(
+                        color: theme.colorScheme.chatlistDiscoverButtonTextColor,
+                      ),
+                    ),
+                    onPressed: () async {
+                      if (room.accessType == RoomAccessType.paid) {
+                        final approved = await _showFakePayment(context, room.price);
+                        if (!approved) return;
+                      }
+
+
+                      try {
+                        await inviteToRoom(
+                          client: client,
+                          keyword: room.keyword,
+                          userId: userId, 
+                        );
+
+                        if (context.mounted) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(content: Text('Entrou no grupo ${room.name}')),
+                          );
+                          Navigator.pop(context);
+                        }
+                      } catch (e) {
+                        if (context.mounted) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(content: Text('Falha ao entrar: $e')),
+                          );
+                        }
+                      }
+                    },
+                  ),
                 ),
-              );
-            },
-          );
-        },
-      ),
-    );
-  }
+              ),
+            );
+          },
+        );
+      },
+    ),
+  );
+}
+
 
   Future<bool> _showFakePayment(BuildContext context, int price) async {
     final theme = Theme.of(context);

--- a/lib/pages/chat_list/rooms_list/discover_rooms_view.dart
+++ b/lib/pages/chat_list/rooms_list/discover_rooms_view.dart
@@ -138,36 +138,6 @@ Widget build(BuildContext context) {
       ),
 
     ),
-    // to do
-    // bottomNavigationBar: SafeArea(
-    //   child: Padding(
-    //     padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
-    //     child: Row(
-    //       mainAxisAlignment: MainAxisAlignment.end,
-    //       children: [
-    //         ElevatedButton.icon(
-    //           style: ElevatedButton.styleFrom(
-    //             shape: RoundedRectangleBorder(
-    //               borderRadius: BorderRadius.circular(8),
-    //             ),
-    //             backgroundColor: theme.colorScheme.chatlistDiscoverButtonColor,
-    //             foregroundColor:
-    //                 theme.colorScheme.chatlistDiscoverButtonTextColor,
-    //             padding: const EdgeInsets.symmetric(
-    //               horizontal: 16,
-    //               vertical: 12,
-    //             ),
-    //           ),
-    //           icon: const Icon(Icons.add),
-    //           label: const Text('Novo Grupo'),
-    //           onPressed: () {
-    //             context.go('/rooms/newgroup');
-    //           },
-    //         ),
-    //       ],
-    //     ),
-    //   ),
-    // ),
     body: FutureBuilder<List<DiscoverRoom>>(
       future: future,
       builder: (context, snapshot) {

--- a/lib/pages/chat_list/rooms_list/discover_rooms_view.dart
+++ b/lib/pages/chat_list/rooms_list/discover_rooms_view.dart
@@ -1,0 +1,285 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:fluffychat/config/themes.dart';
+import 'package:fluffychat/widgets/matrix.dart';
+import 'package:flutter/material.dart';
+import 'package:matrix/matrix.dart';
+
+enum RoomAccessType { free, paid }
+
+class DiscoverRoom {
+  final String name;
+  final String roomId;
+  final RoomAccessType accessType;
+  final int memberCount;
+  final int price;
+
+  DiscoverRoom({
+    required this.name,
+    required this.roomId,
+    required this.accessType,
+    required this.memberCount,
+    required this.price,
+  });
+
+  factory DiscoverRoom.fromJson(Map<String, dynamic> json) {
+    return DiscoverRoom(
+      name: json['name'],
+      roomId: json['room_id'],
+      accessType:
+          json['type'] == 'paid' ? RoomAccessType.paid : RoomAccessType.free,
+      memberCount: json['member_count'],
+      price: json['price'] ?? 0,
+    );
+  }
+}
+
+Future<List<DiscoverRoom>> fetchDiscoverRooms(Client client) async {
+  final uri = Uri.parse(
+    '${client.homeserver}/_matrix/discover/rooms',
+  );
+
+  final response = await http.get(
+    uri,
+    headers: {
+      'Authorization': 'Bearer ${client.accessToken}',
+      'Content-Type': 'application/json',
+    },
+  );
+
+  debugPrint('DISCOVER STATUS: ${response.statusCode}');
+  debugPrint('DISCOVER BODY: ${response.body}');
+
+  if (response.statusCode != 200) {
+    throw Exception(
+      'HTTP ${response.statusCode}: ${response.body}',
+    );
+  }
+
+  final decoded = jsonDecode(utf8.decode(response.bodyBytes));
+
+  if (decoded is! List) {
+    throw Exception('Invalid response format');
+  }
+
+  return decoded
+      .map<DiscoverRoom>(
+        (e) => DiscoverRoom.fromJson(e),
+      )
+      .toList();
+}
+
+Future<void> inviteToCommunity({
+  required Client client,
+  required String community,
+}) async {
+  final uri = Uri.parse(
+    '${client.homeserver}/_matrix/invite',
+  );
+
+  final response = await http.post(
+    uri,
+    headers: {
+      'Authorization': 'Bearer ${client.accessToken}',
+      'Content-Type': 'application/json',
+    },
+    body: jsonEncode({
+      'community': community,
+    }),
+  );
+
+  debugPrint('INVITE STATUS: ${response.statusCode}');
+  debugPrint('INVITE BODY: ${response.body}');
+
+  if (response.statusCode != 200) {
+    throw Exception(
+      'Invite failed: ${response.statusCode} ${response.body}',
+    );
+  }
+}
+
+class DiscoverRoomsView extends StatefulWidget {
+  const DiscoverRoomsView({super.key});
+
+  @override
+  State<DiscoverRoomsView> createState() => _DiscoverRoomsViewState();
+}
+
+class _DiscoverRoomsViewState extends State<DiscoverRoomsView> {
+  late Future<List<DiscoverRoom>> future = Future.value([]);
+
+  @override
+  void initState() {
+    super.initState();
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final client = Matrix.of(context).client;
+      setState(() {
+        future = fetchDiscoverRooms(client);
+      });
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final client = Matrix.of(context).client;
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          'Descobrir Grupos',
+          style: TextStyle(
+            color: theme.colorScheme.chatlistDiscoverTextColor,
+          ),
+        ),
+      ),
+      body: FutureBuilder<List<DiscoverRoom>>(
+        future: future,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          if (snapshot.hasError) {
+            return Center(
+              child: Text(
+                'Erro ao carregar grupos',
+                style: TextStyle(color: theme.colorScheme.error),
+              ),
+            );
+          }
+
+          final rooms = snapshot.data!;
+
+          if (rooms.isEmpty) {
+            return const Center(child: Text('Nenhum grupo disponível'));
+          }
+
+          return ListView.builder(
+            itemCount: rooms.length,
+            itemBuilder: (context, index) {
+              final room = rooms[index];
+
+              return Padding(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                child: Material(
+                  borderRadius: BorderRadius.circular(14),
+                  color: theme.colorScheme.secondary.withValues(alpha: 0.4),
+                  child: ListTile(
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(14),
+                    ),
+                    title: Text(
+                      room.name,
+                      style: TextStyle(
+                        color: theme
+                            .colorScheme.chatlistDiscoverTileGroupNameTextColor,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    subtitle: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          room.accessType == RoomAccessType.paid
+                              ? 'Premium • R\$ ${(room.price / 100).toStringAsFixed(2)}'
+                              : 'Entrada livre',
+                          style: TextStyle(
+                            fontSize: 12,
+                            color: theme.colorScheme
+                                .chatlistDiscoverTileDescriptionTextColor,
+                          ),
+                        ),
+                        const SizedBox(height: 4),
+                        Row(
+                          children: [
+                            Icon(
+                              Icons.person_outline,
+                              size: 16,
+                              color: theme.colorScheme
+                                  .chatlistDiscoverTileDescriptionTextColor,
+                            ),
+                            const SizedBox(width: 4),
+                            Text(
+                              '${room.memberCount} participantes',
+                              style: TextStyle(
+                                fontSize: 12,
+                                color: theme.colorScheme
+                                    .chatlistDiscoverTileDescriptionTextColor,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                    trailing: ElevatedButton(
+                      child: Text(
+                        room.accessType == RoomAccessType.free
+                            ? 'Entrar'
+                            : 'Desbloquear',
+                        style: TextStyle(
+                          color:
+                              theme.colorScheme.chatlistDiscoverButtonTextColor,
+                        ),
+                      ),
+                      onPressed: () async {
+                        if (room.accessType == RoomAccessType.paid) {
+                          final approved =
+                              await _showFakePayment(context, room.price);
+                          if (!approved) return;
+                        }
+
+                        final community = room.accessType == RoomAccessType.paid
+                            ? 'vip'
+                            : 'free';
+
+                        await inviteToCommunity(
+                          client: client,
+                          community: community,
+                        );
+
+                        if (context.mounted) Navigator.pop(context);
+                      },
+                    ),
+                  ),
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+
+  Future<bool> _showFakePayment(BuildContext context, int price) async {
+    final theme = Theme.of(context);
+    final formatted = 'R\$ ${(price / 100).toStringAsFixed(2)}';
+
+    return await showDialog<bool>(
+          context: context,
+          barrierDismissible: false,
+          builder: (dialogContext) => AlertDialog(
+            title: const Text('Pagamento'),
+            content: Text('Confirmar pagamento de $formatted ?'),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(dialogContext, false),
+                child: const Text('Cancelar'),
+              ),
+              ElevatedButton(
+                onPressed: () => Navigator.pop(dialogContext, true),
+                child: Text(
+                  'Pagar',
+                  style: TextStyle(
+                    color: theme.colorScheme.chatlistDiscoverButtonTextColor,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ) ??
+        false;
+  }
+}

--- a/lib/pages/chat_list/rooms_list/discover_rooms_view.dart
+++ b/lib/pages/chat_list/rooms_list/discover_rooms_view.dart
@@ -138,35 +138,36 @@ Widget build(BuildContext context) {
       ),
 
     ),
-    bottomNavigationBar: SafeArea(
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.end,
-          children: [
-            ElevatedButton.icon(
-              style: ElevatedButton.styleFrom(
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(8),
-                ),
-                backgroundColor: theme.colorScheme.chatlistDiscoverButtonColor,
-                foregroundColor:
-                    theme.colorScheme.chatlistDiscoverButtonTextColor,
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 16,
-                  vertical: 12,
-                ),
-              ),
-              icon: const Icon(Icons.add),
-              label: const Text('Novo Grupo'),
-              onPressed: () {
-                context.go('/rooms/newgroup');
-              },
-            ),
-          ],
-        ),
-      ),
-    ),
+    // to do
+    // bottomNavigationBar: SafeArea(
+    //   child: Padding(
+    //     padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+    //     child: Row(
+    //       mainAxisAlignment: MainAxisAlignment.end,
+    //       children: [
+    //         ElevatedButton.icon(
+    //           style: ElevatedButton.styleFrom(
+    //             shape: RoundedRectangleBorder(
+    //               borderRadius: BorderRadius.circular(8),
+    //             ),
+    //             backgroundColor: theme.colorScheme.chatlistDiscoverButtonColor,
+    //             foregroundColor:
+    //                 theme.colorScheme.chatlistDiscoverButtonTextColor,
+    //             padding: const EdgeInsets.symmetric(
+    //               horizontal: 16,
+    //               vertical: 12,
+    //             ),
+    //           ),
+    //           icon: const Icon(Icons.add),
+    //           label: const Text('Novo Grupo'),
+    //           onPressed: () {
+    //             context.go('/rooms/newgroup');
+    //           },
+    //         ),
+    //       ],
+    //     ),
+    //   ),
+    // ),
     body: FutureBuilder<List<DiscoverRoom>>(
       future: future,
       builder: (context, snapshot) {


### PR DESCRIPTION
This PR introduces a room discovery and join flow in the Flutter client, integrating with the custom Synapse discover rooms and invite modules.

It adds a new Discover Rooms view that:
- Fetches available rooms from the /​_matrix/admin/rooms endpoint
- Displays room metadata such as name, member count, access type (free / paid), and price
- Allows users to join free rooms immediately
- Simulates a payment confirmation flow for paid rooms before joining
- Uses a controlled invite endpoint (/​_matrix/invite) to join users to rooms

This enables a product-oriented experience where users can discover communities, join free groups, or unlock paid/private groups, while keeping room membership and permissions fully managed by Synapse.

The payment flow is currently mocked and intended for future integration with a real billing system.