### PR TITLE
feat: add rest auth provider

### DIFF
--- a/lib/pages/login/login.dart
+++ b/lib/pages/login/login.dart
@@ -107,7 +107,10 @@ class LoginController extends State<Login> {
       initialDeviceDisplayName: PlatformInfos.clientName,
     );
 
-
+      // This block was commented out because the authentication flow was simplified to use email-only login, 
+      // avoiding the automatic detection of multiple identifier types (email, phone number, and userId), which 
+      // is unnecessary in the current scenario and may cause inconsistencies with the authentication backend.
+      //
       // final username = usernameController.text;
       // AuthenticationIdentifier identifier;
       // if (username.isEmail) {

--- a/lib/pages/login/login.dart
+++ b/lib/pages/login/login.dart
@@ -92,33 +92,49 @@ class LoginController extends State<Login> {
     _coolDown?.cancel();
 
     try {
-      final username = usernameController.text;
-      AuthenticationIdentifier identifier;
-      if (username.isEmail) {
-        identifier = AuthenticationThirdPartyIdentifier(
-          medium: 'email',
-          address: username,
-        );
-      } else if (username.isPhoneNumber) {
-        identifier = AuthenticationThirdPartyIdentifier(
-          medium: 'msisdn',
-          address: username,
-        );
-      } else {
-        identifier = AuthenticationUserIdentifier(user: username);
-      }
-      final client = await matrix.getLoginClient();
-      await client.login(
-        LoginType.mLoginPassword,
-        identifier: identifier,
-        // To stay compatible with older server versions
-        // ignore: deprecated_member_use
-        user: identifier.type == AuthenticationIdentifierTypes.userId
-            ? username
-            : null,
-        password: passwordController.text,
-        initialDeviceDisplayName: PlatformInfos.clientName,
-      );
+    final email = usernameController.text.trim();
+
+    final identifier = AuthenticationUserIdentifier(
+      user: email, 
+    );
+
+    final client = await matrix.getLoginClient();
+
+    await client.login(
+      LoginType.mLoginPassword,
+      identifier: identifier,
+      password: passwordController.text,
+      initialDeviceDisplayName: PlatformInfos.clientName,
+    );
+
+
+      // final username = usernameController.text;
+      // AuthenticationIdentifier identifier;
+      // if (username.isEmail) {
+      //   identifier = AuthenticationThirdPartyIdentifier(
+      //     medium: 'email',
+      //     address: username,
+      //   );
+      // } else if (username.isPhoneNumber) {
+      //   identifier = AuthenticationThirdPartyIdentifier(
+      //     medium: 'msisdn',
+      //     address: username,
+      //   );
+      // } else {
+      //   identifier = AuthenticationUserIdentifier(user: username);
+      // }
+      // final client = await matrix.getLoginClient();
+      // await client.login(
+      //   LoginType.mLoginPassword,
+      //   identifier: identifier,
+      //   // To stay compatible with older server versions
+      //   // ignore: deprecated_member_use
+      //   user: identifier.type == AuthenticationIdentifierTypes.userId
+      //       ? username
+      //       : null,
+      //   password: passwordController.text,
+      //   initialDeviceDisplayName: PlatformInfos.clientName,
+      // );
     } on MatrixException catch (exception) {
       String errorMessage;
 


### PR DESCRIPTION
# REST Auth Provider for Matrix Synapse

This module implements a custom **password authentication provider**
for Matrix Synapse using an **external REST API** (paywall / authentication service).

It allows Synapse to:

- authenticate users against an external service
- automatically create Matrix users on first successful login
- generate Matrix user IDs based on external user data

This module **does not expose a registration endpoint**.  
User creation happens implicitly during login if the user does not exist.

---

## How it works

1. Synapse receives a login request using `m.login.password`
2. Synapse calls `check_auth` on this provider
3. The provider:
   - extracts the user email from the login identifier
   - hashes the password using **SHA-512**
   - sends the credentials to an external REST API
   - validates the API response
   - generates a Matrix localpart
   - creates the Matrix user if it does not exist
4. If authentication succeeds, Synapse completes the login flow

---

## Login identifier

The login identifier **must be an email address**.

Examples:

- `user@example.com`
- `User@Example.com` (normalized internally)

If the identifier is not a valid email address, authentication will be rejected.

---

## External REST API contract

Your authentication backend must expose the following endpoint.

### Endpoint

POST /public/authenticate
(The base URL is defined by `api_base` in the Synapse configuration.)

---

### Request body

The request body must be JSON, UTF-8 encoded.

The password **must be hashed using SHA-512** before being sent.

```json
{
  "subscriber-user/email": "user@example.com",
  "subscriber-user/password": "<sha512 hex digest>"
}
```
### Successful response
The API must return HTTP 200 with a JSON object containing
at least the following fields:
```
{
  "id": "external-user-id",
  "email": "user@example.com",
  "info": {
    "first-name": "Alice",
    "last-name": "Silva"
  }
}
```
- email is required
- id is required only as a validation field
- the id value is not stored and not used to generate the Matrix user ID
- info.first-name and info.last-name are optional

### Failed authentication
Authentication will fail if:
- credentials are invalid (non-200 HTTP response), or
- required fields (email, id) are missing or malformed
In these cases, Synapse will reject the login attempt.

### Matrix user creation
If authentication succeeds and the Matrix user does not exist:
- the user is created automatically
- the Matrix localpart is generated as follows: 
  - first_last if both first and last name are present
  - otherwise, the email local part (before @)
- the localpart is normalized to: 
  - lowercase
  - ASCII characters only
  - non-alphanumeric characters replaced with _

##  Configuration

Example homeserver.yaml configuration:
``` 
password_config:
  enabled: true
  localdb_enabled: false

password_providers:
  - module: modules.rest_auth_provider.rest_auth_provider.RestAuthProvider
    config:
      api_base: "https://example.paywall.com"
      homeserver: "example.com"
```